### PR TITLE
Issue #6 Add a config setting for editing the API key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Google Font API.
 
 It is a port to BackdropCMS of the Drupal project, version 7.x-2.3.
 
-Note that the author now recommends adopting the more general 
-@font-your-face module that not only support Google Fonts, 
-but also several other font providers and combines all those fonts 
-in a very user-friendly interface. 
-
+This latest release 1.x-2.1.3 of the module for BackdropCMS adds 
+an administrative setting for the Google Webfonts API Key which is 
+needed for fetching an up-to-date listing of all available Google fonts.
 
 ## Installation
 
@@ -17,9 +15,13 @@ Install this module using the official Backdrop CMS instructions at
 https://backdropcms.org/guide/modules.
 
 Visit the configuration page at 
-Administration > Configuration > Category >  Google Fonts 
-(admin/config/category/google_fonts) 
+Administration > Configuration > System > Google Fonts 
+(admin/config/system/google_fonts) 
 and enter the required information.
+
+Please note that when fetching the listing of all available 
+Google fonts this module stores the information in its config
+file which then becomes large, nearly 900 kilobytes.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Google Font API.
 
 It is a port to BackdropCMS of the Drupal project, version 7.x-2.3.
 
-This latest release 1.x-2.1.3 of the module for BackdropCMS adds 
+This latest release 1.x-2.1.3 of the module for Backdrop CMS adds 
 an administrative setting for the Google Webfonts API Key which is 
 needed for fetching an up-to-date listing of all available Google fonts.
 
@@ -19,33 +19,25 @@ Administration > Configuration > System > Google Fonts
 (admin/config/system/google_fonts) 
 and enter the required information.
 
+## Issues
+Bugs and Feature requests should be reported in the Issue Queue:
+https://github.com/backdrop-contrib/google_fonts/issues.
+
 Please note that when fetching the listing of all available 
 Google fonts this module stores the information in its config
 file which then becomes large, nearly 900 kilobytes.
 
-
-## License
-
-This project is GPL v2 software. See the LICENSE.txt file 
-in this directory for complete text.
-
-## Acknowledgements
-
-### Author and Maintainer for Drupal:
-
-+ Baris Wanschers (BarisW)
-
-
-### Port to Backdrop:
-
+## Current maintainers
 + Graham Oliver (github.com/Graham-72)
-
++ Seeking new maintainer
 
 ## Credits
++ Ported to Backdrop CMS by Graham Oliver (github.com/Graham-72)
++ Originally written for Drupal by Baris Wanschers (BarisW)
++ Development of the Drupal module was sponsored by 
+  LimoenGroen, Amsterdam-based Drupal specialists.
 
-Development of the Drupal module was sponsored by 
-LimoenGroen, Amsterdam-based Drupal specialists.
-
-
-
+## License
+This project is GPL v2 software. 
+See the LICENSE.txt file in this directory for complete text.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This module enables you to add Google Fonts to your site using the 
 Google Font API.
 
-It is a port to BackdropCMS of the Drupal project, version 7.x-2.3.
+It is a port to Backdrop CMS of the Drupal project, version 7.x-2.3.
 
-This latest release 1.x-2.1.3 of the module for Backdrop CMS adds 
+This latest release 1.x-2.1.3 of this module for Backdrop CMS adds 
 an administrative setting for the Google Webfonts API Key which is 
 needed for fetching an up-to-date listing of all available Google fonts.
 
@@ -18,6 +18,10 @@ Visit the configuration page at
 Administration > Configuration > System > Google Fonts 
 (admin/config/system/google_fonts) 
 and enter the required information.
+
+Visit https://developers.google.com/fonts/docs/developer_api
+to obtain your own API key to replace the one included in
+this release.
 
 ## Issues
 Bugs and Feature requests should be reported in the Issue Queue:

--- a/google_fonts.admin.inc
+++ b/google_fonts.admin.inc
@@ -15,8 +15,17 @@ function google_fonts_admin_settings_form($form, &$form_state) {
   $form = array(
     '#attributes' => array('class' => array('google_fonts_admin_form')),
   );
+
+  $form['google_fonts_api_key'] = array(
+    '#title' => t('The Google webfonts API key for fetching an up-to-date list of all available fonts.'),
+    '#description' => t('Use this default key or obtain and insert your own here.'),
+    '#type' => 'textfield',
+    '#default_value' => config_get('google_fonts.settings','google_fonts_api_key'),
+    '#weight' => -1,
+  );
+
   $form['introduction'] = array(
-    '#markup' => '<p>' . t('Select the fonts that you want to be available on your website. Keep in mind that each font takes some time to download. For the best performance, only enable fonts that you are actually using on your website. More information about these fonts is available on the <a href="!link">Google font directory</a>.', array('!link' => 'http://developers.google.com/fonts')) . '</p>',
+    '#markup' => '<h2>' . t('Selecting fonts:') . '</h2>' . '<p>' . t('From the list below select the fonts that you want to be available on your website. Keep in mind that each font takes some time to download. For the best performance, only enable fonts that you are actually using on your website. More information about these fonts is available on the <a href="!link">Google font directory</a>.', array('!link' => 'http://developers.google.com/fonts')) . '</p>',
   );
 
   $all_fonts = _google_fonts_available_fonts();
@@ -68,7 +77,7 @@ function google_fonts_admin_settings_form($form, &$form_state) {
         $enabled_fonts[$key]['variants'] = array('regular' => 'regular');
       }
       elseif (array_search('400', $font->variants)) {
-        // a weight of 400 is usally the default when there is no general
+        // a weight of 400 is usually the default when there is no general
         $enabled_fonts[$key]['variants'] = array('400' => '400');
       }
       else {
@@ -173,6 +182,9 @@ function google_fonts_admin_settings_form($form, &$form_state) {
 function google_fonts_admin_settings_form_submit($form, &$form_state) {
 
   $enabled_fonts = array();
+
+  $webfonts_api = $form_state['values']['google_fonts_api_key'];
+  config_set('google_fonts.settings', 'google_fonts_api_key', $webfonts_api);
 
   if (isset($form_state['values']['enabled_fonts'])) {
     foreach ($form_state['values']['enabled_fonts'] as $key => $font) {

--- a/google_fonts.install
+++ b/google_fonts.install
@@ -32,3 +32,17 @@ function google_fonts_update_1000() {
   update_variable_del('google_fonts_webfonts');
   update_variable_del('google_fonts_enabled_fonts');
 }
+
+/**
+ *  Add a config setting for Google webfonts API key
+ */
+function google_fonts_update_1001()
+{
+  // Add a default value for the API key.
+  $existing_key = config_get('google_fonts.settings', 'google_fonts_api_key');
+  if (!isset($existing_key)) {
+    $config = config('google_fonts.settings');
+    $config->set('google_fonts_api_key', 'AIzaSyDqIX-7e02ozn6JB5ADu0ZX5eTfrN2n3io');
+    $config->save();
+  }
+}

--- a/google_fonts.module
+++ b/google_fonts.module
@@ -95,7 +95,7 @@ function _google_fonts_available_fonts($reset = FALSE) {
   $fontslist = config_get('google_fonts.settings', 'google_fonts_webfonts');
 
   //new for Backdrop
-  //convert each entry into a stdClass object  
+  //convert each entry into a stdClass object
   //and build $fontsbuffer as an array of objects
 
   $fontsbuffer = array();
@@ -114,16 +114,25 @@ function _google_fonts_available_fonts($reset = FALSE) {
   }
 
   if (empty($fontsbuffer) || $reset) {
-    // Return the JSON object with all available fonts
-    // For now, it uses my (BarisW) API key
+    // Return the JSON object with all available fonts.
+    // This requires an API key for the Google webfonts service.
 
-    // This key is limited to 10.000 requests per day, which should
-    // be sufficient as it is only used when selecting fonts in the
-    // admin interface. After that, it's cached in Drupal.
+    // This is only used when selecting fonts in the
+    // admin interface. After that, the results are cached in Backdrop.
+    // Go to https://developers.google.com/fonts/docs/developer_api
+    // to obtain your own API key.
 
-    $result = backdrop_http_request('https://www.googleapis.com/webfonts/v1/webfonts?key=AIzaSyBgeqKlFdYj3Y7VwmrEXnXzpnx5TfKXG4o');
+    // The 'out-of-the box' setting is my (Graham-72) API key.
+    // $webfonts_api_key = 'AIzaSyDqIX-7e02ozn6JB5ADu0ZX5eTfrN2n3io';
+    // Get current API key from config.
+    $webfonts_api_key = config_get('google_fonts.settings', 'google_fonts_api_key');
+    $webfonts_uri = "https://www.googleapis.com/webfonts/v1/webfonts?key=$webfonts_api_key";
+
+    $result = backdrop_http_request($webfonts_uri);
     if ($result->code != 200) {
-      backdrop_set_message(t('The list of Google Fonts could not be fetched. Verify that your server can connect the Google Servers (https://www.googleapis.com). Error: %error', array('%error' => $result->error)), 'error');
+      backdrop_set_message(t('The list of Google Fonts could not be fetched.
+      Check that you have set a valid API key and that your server can connect the Google Servers 
+      (https://www.googleapis.com). Error: %error', array('%error' => $result->error)), 'error');
     }
     elseif (isset($result->data)) {
 
@@ -141,7 +150,7 @@ function _google_fonts_available_fonts($reset = FALSE) {
 function _google_fonts_update_font_list() {
   $fonts = _google_fonts_available_fonts(TRUE);
   if (!empty($fonts)) {
-    backdrop_set_message(t('A new list of fonts have been fetched.'));
+    backdrop_set_message(t('A new list of fonts has been fetched.'));
   }
   backdrop_goto('admin/config/system/google_fonts');
 }
@@ -167,7 +176,7 @@ function _google_fonts_family_pathname($family, $variants = NULL, $subsets = NUL
     }
   }
 
-  // for latin, we don't need to declare a subset. 
+  // for latin, we don't need to declare a subset.
   if (!empty($subsets)) {
     $string .= '&subset=';
     foreach ((array) $subsets as $subset) {


### PR DESCRIPTION
It seems that the old Google webfonts API key is no longer valid and so it had become impossible to obtain or update the list of available fonts. This PR includes a new key that I have obtained and provides for the admin to replace this with their own key.